### PR TITLE
test: add failing test case w/ closure-elimination

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,11 @@
     "babel-cli": "^6.8.0",
     "babel-core": "^6.7.7",
     "babel-plugin-add-module-exports": "~0.2.1",
+    "babel-plugin-closure-elimination": "^1.0.6",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
+    "babel-preset-stage-1": "^6.5.0",
     "lodash-compat": "^3.10.2",
     "lodash-es": "^4.12.0",
     "mocha": "^2.4.5"

--- a/test/acceptance-fixtures/closure-elimination-regeneratorRuntime/actual.js
+++ b/test/acceptance-fixtures/closure-elimination-regeneratorRuntime/actual.js
@@ -1,0 +1,5 @@
+import { sortBy } from 'lodash'
+
+async function editThing () {
+
+}

--- a/test/acceptance-fixtures/closure-elimination-regeneratorRuntime/babelrc.json
+++ b/test/acceptance-fixtures/closure-elimination-regeneratorRuntime/babelrc.json
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    "es2015",
+    "stage-1"
+  ],
+  "plugins": [
+    "transform-runtime",
+    "closure-elimination"
+  ]
+}

--- a/test/acceptance-fixtures/closure-elimination-regeneratorRuntime/expected.js
+++ b/test/acceptance-fixtures/closure-elimination-regeneratorRuntime/expected.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var _regenerator = require('babel-runtime/regenerator');
+
+var _regenerator2 = _interopRequireDefault(_regenerator);
+
+var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
+
+var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
+
+var _sortBy2 = require('lodash/sortBy');
+
+var _sortBy3 = _interopRequireDefault(_sortBy2);
+
+var editThing = function () {
+  var ref = (0, _asyncToGenerator3.default)(_ref);
+  return function editThing() {
+    return ref.apply(this, arguments);
+  };
+}();
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var _marked = [_ref].map(_regenerator2.default.mark);
+
+function _ref2(_context) {
+  while (1) {
+    switch (_context.prev = _context.next) {
+      case 0:
+      case 'end':
+        return _context.stop();
+    }
+  }
+}
+
+function _ref() {
+  return _regenerator2.default.wrap(_ref2, _marked[0], this);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -59,4 +59,22 @@ describe('cherry-picked modular builds', () => {
       }).code;
     });
   });
+
+  /*--------------------------------------------------------------------------*/
+
+  _.each(glob.sync(path.join(__dirname, 'acceptance-fixtures/*/')), testPath => {
+    const testName = _.lowerCase(path.basename(testPath));
+    const lodashId = getLodashId(testName);
+    const actualPath = path.join(testPath, 'actual.js');
+    const expectedPath = path.join(testPath, 'expected.js');
+    const babelOptions = require(path.join(testPath, 'babelrc.json'));
+    babelOptions.plugins.push([plugin, { 'id': lodashId }]);
+
+    it(`should work with ${ testName }`, () => {
+      const expected = fs.readFileSync(expectedPath, 'utf8');
+      const actual = transformFileSync(actualPath, babelOptions).code;
+
+      assert.strictEqual(_.trim(actual), _.trim(expected));
+    });
+  });
 });


### PR DESCRIPTION
result: 

```
      AssertionError: '\'use strict\';\n\nvar _regenerator = require(\'babel-runtime/regenerator\');\n\nvar _regenerator2 = _interopRequireDefault(_re === '\'use strict\';\n\nvar _regenerator = require(\'babel-runtime/regenerator\');\n\nvar _regenerator2 = _interopRequireDefault(_re
      + expected - actual

       }();
       
       function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
       
      -var _marked = [_ref].map(_regeneratorRuntime.mark);
      +var _marked = [_ref].map(_regenerator2.default.mark);
       
       function _ref2(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
```