### PR TITLE
Fix new "main" sorting on Windows

### DIFF
--- a/src/ModuleCache.js
+++ b/src/ModuleCache.js
@@ -17,7 +17,7 @@ export default class ModuleCache extends MapCache {
     }
     const pkgPath = path.join(moduleRoot, 'package.json');
     const pkg = fs.existsSync(pkgPath) ? require(pkgPath) : { 'main': 'index.js' };
-    const mainPath = path.dirname(path.resolve(moduleRoot, pkg.main));
+    const mainPath = path.dirname(path.resolve(moduleRoot, pkg.main)).replace(/\\/g, '/');
 
     // Sort paths by the “main” entry first.
     const dirPaths = _.orderBy(glob.sync(path.join(moduleRoot, '**/'), {


### PR DESCRIPTION
`mainPath` has backslashes on Windows, while paths from `glob.sync()` have forward-slashes, so the `main` directory doesn't get sorted to the top.

Before:
```
{ mainPath: 'C:\\Users\\Jonny\\AppData\\Local\\Temp\\cherry-pick116716-476-10vp4jb.9nqsb2csor\\node_modules\\react-bootstrap\\lib' }
{ dirPaths:
   [ 'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-476-10vp4jb.9nqsb2csor/node_modules/react-bootstrap/',
     'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-476-10vp4jb.9nqsb2csor/node_modules/react-bootstrap/dist/',
     'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-476-10vp4jb.9nqsb2csor/node_modules/react-bootstrap/es/',
     'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-476-10vp4jb.9nqsb2csor/node_modules/react-bootstrap/es/utils/',
     'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-476-10vp4jb.9nqsb2csor/node_modules/react-bootstrap/lib/',
     'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-476-10vp4jb.9nqsb2csor/node_modules/react-bootstrap/lib/utils/' ] }
```

After:
```
{ mainPath: 'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-5180-13kveek.s66k249529/node_modules/react-bootstrap/lib' }
{ dirPaths:
   [ 'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-5180-13kveek.s66k249529/node_modules/react-bootstrap/lib/',
     'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-5180-13kveek.s66k249529/node_modules/react-bootstrap/lib/utils/',
     'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-5180-13kveek.s66k249529/node_modules/react-bootstrap/',
     'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-5180-13kveek.s66k249529/node_modules/react-bootstrap/dist/',
     'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-5180-13kveek.s66k249529/node_modules/react-bootstrap/es/',
     'C:/Users/Jonny/AppData/Local/Temp/cherry-pick116716-5180-13kveek.s66k249529/node_modules/react-bootstrap/es/utils/' ] }
```