### PR TITLE
More descriptive error messages when encountering missing modules

### DIFF
--- a/src/importModule.js
+++ b/src/importModule.js
@@ -12,7 +12,7 @@ function resolvePath(pkgStore, name) {
     base = base ? '' : module.findKey(map => map.has(lower));
     if (!base) {
       throw new Error([
-        `The '${ id }' method ${ name } is not a known module.`,
+        `The '${ id }' method '${ name }' is not a known module.`,
         'Please report bugs to https://github.com/lodash/babel-plugin-lodash/issues.'
       ].join('\n'));
     }

--- a/src/importModule.js
+++ b/src/importModule.js
@@ -3,7 +3,7 @@ import mapping from './mapping';
 
 /*----------------------------------------------------------------------------*/
 
-function resolvePath(pkgStore, name) {
+function resolvePath(pkgStore, name, path) {
   let { base, id } = pkgStore;
   const lower = name.toLowerCase();
   const module = mapping.modules.get(id);
@@ -11,17 +11,17 @@ function resolvePath(pkgStore, name) {
   if (!module.get(base).has(lower)) {
     base = base ? '' : module.findKey(map => map.has(lower));
     if (!base) {
-      throw new Error([
+      throw path.buildCodeFrameError([
         `The '${ id }' method '${ name }' is not a known module.`,
         'Please report bugs to https://github.com/lodash/babel-plugin-lodash/issues.'
-      ].join('\n'));
+      ].join('\n'), Error);
     }
   }
   return id + '/' + (base ? base + '/' : '') + module.get(base).get(lower);
 }
 
-function importModule(pkgStore, name, file) {
-  return file.addImport(resolvePath(pkgStore, name), 'default', name);
+function importModule(pkgStore, name, file, path) {
+  return file.addImport(resolvePath(pkgStore, name, path), 'default', name);
 }
 
 export default _.memoize(importModule, (pkgStore, name) => (pkgStore.path + '/' + name).toLowerCase());

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ export default function lodash({ types }) {
               if (isChain && refPath.parentPath.isCallExpression()) {
                 throw refPath.buildCodeFrameError(CHAIN_ERROR);
               }
-              const { name } = importModule(pkgStore, imported, file);
+              const { name } = importModule(pkgStore, imported, file, refPath);
               refPath.replaceWith({ type, name });
             }
             else if (parentPath.isMemberExpression()) {
@@ -95,7 +95,7 @@ export default function lodash({ types }) {
               if (isLodash && key == 'chain' && parentPath.parentPath.isCallExpression()) {
                 throw refPath.buildCodeFrameError(CHAIN_ERROR);
               }
-              const { name } = importModule(pkgStore, key, file);
+              const { name } = importModule(pkgStore, key, file, refPath);
               parentPath.replaceWith({ type, name });
             }
             else if (isLodash) {
@@ -130,7 +130,7 @@ export default function lodash({ types }) {
       }
       node.source = null;
       _.each(node.specifiers, spec => {
-        spec.local = importModule(pkgStore, spec.local.name, path.hub.file);
+        spec.local = importModule(pkgStore, spec.local.name, path.hub.file, path);
       });
     }
   };


### PR DESCRIPTION
Adds more descriptive error messages when encountering missing methods.  (Helpful for tracking down lingering usages of deprecated lodash methods)

### Before:

```
The 'lodash' method call is not a known module.
Please report bugs to https://github.com/lodash/babel-plugin-lodash/issues.
```

### After:
```
Error: /Users/schmod/source/badFile.js: The 'lodash' method 'call' is not a known module.
Please report bugs to https://github.com/lodash/babel-plugin-lodash/issues.
  186 |
  187 |     var something = function(){
> 188 |         return _.some(_.invokeMap(somethingElse, _.call)) &&
      |                                                  ^
  189 |             !window.confirm("are you sure?");
  190 |     };
  191 |
    at File.buildCodeFrameError (/Users/schmod/foo/node_modules/babel-core/lib/transformation/file/index.js:446:15)
    at NodePath.buildCodeFrameError (/Users/schmod/foo/node_modules/babel-traverse/lib/path/index.js:143:26)
```

---

This original error was particularly frustrating, because "call" looked like generic JavaScript nonsense, rather than a legitimately helpful message telling me that I was using `_.call`, which isn't quite a real module.