### PR TITLE
Handle scoped packages correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "mocha --check-leaks --compilers js:babel-register"
   },
   "devDependencies": {
+    "@storybook/addon-links": "^3.2.0",
     "async": "^2.4.1",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
@@ -40,7 +41,8 @@
   },
   "dependencies": {
     "glob": "^7.1.1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "require-package-name": "^2.0.1"
   },
   "files": [
     "lib"

--- a/src/Package.js
+++ b/src/Package.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import requirePackageName from 'require-package-name';
 
 const reLodash = /^lodash(?:-compat|-es)?$/;
 
@@ -7,10 +8,10 @@ const reLodash = /^lodash(?:-compat|-es)?$/;
 export default class Package {
   constructor(pkgPath) {
     pkgPath = _.toString(pkgPath);
-    const parts = pkgPath.split('/');
+    const pkgName = requirePackageName(pkgPath);
 
-    this.base = _.tail(parts).join('/');
-    this.id = parts[0];
+    this.base = pkgPath.replace(new RegExp(pkgName + '/?'), '');
+    this.id = pkgName;
     this.isLodash = _.constant(reLodash.test(this.id));
     this.path = pkgPath;
   }

--- a/test/fixtures/scoped-module/actual.js
+++ b/test/fixtures/scoped-module/actual.js
@@ -1,0 +1,3 @@
+import { register } from '@storybook/addon-links';
+
+export default register;

--- a/test/fixtures/scoped-module/expected.js
+++ b/test/fixtures/scoped-module/expected.js
@@ -1,0 +1,13 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _register2 = require('@storybook/addon-links/register');
+
+var _register3 = _interopRequireDefault(_register2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = _register3.default;

--- a/test/index.js
+++ b/test/index.js
@@ -29,7 +29,7 @@ describe('cherry-picked modular builds', function() {
     it(`should work with ${ testName }`, () => {
       const expected = fs.readFileSync(expectedPath, 'utf8');
       const actual = transformFileSync(actualPath, {
-        'plugins': [[plugin, { 'id': lodashId }]]
+        'plugins': [[plugin, { 'id': [lodashId, '@storybook/addon-links'] }]]
       }).code;
 
       assert.strictEqual(_.trim(actual), _.trim(expected));


### PR DESCRIPTION
Before, `babel-plugin-lodash` was choking on scoped packages (e.g. `@myscope/my-pkg`). This PR fixes this.