### PR TITLE
Tweak README suggestion for preserving ES2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ require('babel-core').transform('code', {
 This plugin produces ES2015 imports by default. The
 [transform-es2015-modules-commonjs](https://www.npmjs.com/package/babel-plugin-transform-es2015-modules-commonjs)
 plugin, which is included in the Babel [es2015](http://babeljs.io/docs/plugins/preset-es2015/)
-preset, transforms ES2015 `import` statements to CommonJS. Omit it from your
-preset to preserve ES2015 style imports.
+preset, transforms ES2015 `import` statements to CommonJS. Configure your preset as `[["es2015"], {"modules": false}]` to preserve ES2015 style imports.
 
 ## Limitations
 


### PR DESCRIPTION
The existing documentation suggests omitting the `transform-es2015-modules-commonjs` plugin, but there's [not really a way to omit individual plugins from babel presets](http://discuss.babeljs.io/t/can-i-disable-omit-a-plugin-from-a-preset/90), but the "es2015" preset does support an option which disables the module transformation, so this PR changes the readme to suggest that, instead.