### PR TITLE
Update readme to use env and not es2015 as example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ _map([1, 2, 3], addOne);
 ```json
 {
   "plugins": ["lodash"],
-  "presets": ["es2015"]
+  "presets": [["env", { "targets": { "node": 4 } }]]
 }
 ```
 


### PR DESCRIPTION
The first example still used es2015 which is a bit misleading since it's not part of the install suggestions :)