### PR TITLE
migrate to isImportOrExportDeclaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.0.0",
-    "@babel/types": "^7.0.0",
+    "@babel/types": "^7.21.0",
     "glob": "^7.1.1",
     "lodash": "^4.17.10",
     "require-package-name": "^2.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { isModuleDeclaration } from '@babel/types'
+import { isImportOrExportDeclaration } from '@babel/types'
 
 import config from './config'
 import importModule from './importModule'
@@ -72,7 +72,7 @@ export default function lodash({ types }) {
       let isModule = false
 
       for (const node of file.ast.program.body) {
-        if (isModuleDeclaration(node)) {
+        if (isImportOrExportDeclaration(node)) {
           isModule = true
           break
         }


### PR DESCRIPTION
Babel has deprecated isModuleDeclaration(); see [here](https://github.com/babel/babel/blob/a2fdc207ce158cf0d8eea08c1301d58f3810fd44/packages/babel-types/src/validators/generated/index.ts#L5862). 

**NOTE:** isModuleDeclaration() is now a shim for [isImportOrExportDeclaration](https://github.com/babel/babel/blob/a2fdc207ce158cf0d8eea08c1301d58f3810fd44/packages/babel-types/src/validators/generated/index.ts#L5188)() and has no purpose other than to generate a TON of these messages:

```
Trace: `isModuleDeclaration` has been deprecated, please migrate to `isImportOrExportDeclaration`.
    at isModuleDeclaration ( [...] /node_modules/@babel/types/src/validators/generated/index.ts:5869:11)
    at PluginPass.call ( [...] /node_modules/babel-plugin-lodash/lib/index.js:102:44)
    at call ( [...] /node_modules/@babel/traverse/src/visitors.ts:261:21)
    at NodePath._call ( [...] /node_modules/@babel/traverse/src/path/context.ts:34:20)
    at NodePath.call ( [...] /node_modules/@babel/traverse/src/path/context.ts:19:17)
    at NodePath.visit ( [...] /node_modules/@babel/traverse/src/path/context.ts:92:31)
    at TraversalContext.visitQueue ( [...] /node_modules/@babel/traverse/src/context.ts:144:16)
    at TraversalContext.visitSingle ( [...] /node_modules/@babel/traverse/src/context.ts:108:19)
    at TraversalContext.visit ( [...] /node_modules/@babel/traverse/src/context.ts:176:19)
    at traverseNode ( [...] /node_modules/@babel/traverse/src/traverse-node.ts:34:17)
    at traverse ( [...] /node_modules/@babel/traverse/src/index.ts:71:15)
    at transformFile ( [...] /node_modules/@babel/core/src/transformation/index.ts:119:13)
    at transformFile.next (<anonymous>)
    at run ( [...] /node_modules/@babel/core/src/transformation/index.ts:47:12)
    at run.next (<anonymous>)
    at transform ( [...] /node_modules/@babel/core/src/transform.ts:29:20)
    at transform.next (<anonymous>)
    at step ( [...] /node_modules/gensync/index.js:261:32)
    at  [...] /node_modules/gensync/index.js:273:13
    at async.call.result.err.err ( [...] /node_modules/gensync/index.js:223:11)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```
Thanks for considering this PR.
