### PR TITLE
Rename to `@sigmacomputing/babel-plugin-lodash` and fix module declaration bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "babel-plugin-lodash",
+  "name": "@sigmacomputing/babel-plugin-lodash",
   "version": "3.3.4",
   "description": "Modular Lodash builds without the hassle.",
-  "keywords": "babel-plugin, cherry-pick, lodash, modules",
+  "keywords": [
+    "babel-plugin",
+    "cherry-pick",
+    "lodash",
+    "modules"
+  ],
   "repository": "lodash/babel-plugin-lodash",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigmacomputing/babel-plugin-lodash",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "Modular Lodash builds without the hassle.",
   "keywords": [
     "babel-plugin",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { isModuleDeclaration } from '@babel/types'
+import { isImportDeclaration, isExportDeclaration } from '@babel/types'
 
 import config from './config'
 import importModule from './importModule'
@@ -72,7 +72,7 @@ export default function lodash({ types }) {
       let isModule = false
 
       for (const node of file.ast.program.body) {
-        if (isModuleDeclaration(node)) {
+        if (isImportDeclaration(node) || isExportDeclaration(node)) {
           isModule = true
           break
         }


### PR DESCRIPTION
See https://github.com/lodash/babel-plugin-lodash/pull/261 for the issue being fixed